### PR TITLE
fix: allow sliding window to match previous paragraph near boundaries

### DIFF
--- a/App.js
+++ b/App.js
@@ -422,15 +422,17 @@ export default function App() {
             // Check if this is a valid sequential progression
             const isSameParagraph = isSameSection && ctx.currentParagraphNum === match.paragraphNum;
             const isNextParagraph = isSameSection && match.paragraphNum === ctx.currentParagraphNum + 1;
+            // Sliding window can temporarily match the previous paragraph near boundaries — don't reset
+            const isPrevParagraph = isSameSection && match.paragraphNum === ctx.currentParagraphNum - 1;
             // Re-lock: switching to a better document but landing on same paragraph we already confirmed
             const isRelock = !isSameSection && match.paragraphNum === ctx.currentParagraphNum;
-            const isValidProgression = isSameParagraph || isNextParagraph || isRelock;
+            const isValidProgression = isSameParagraph || isNextParagraph || isPrevParagraph || isRelock;
 
             let firstParagraphIndex;
             if (isValidProgression && ctx.firstParagraphNum !== null) {
               // Valid progression: keep tracking from first matched paragraph
               firstParagraphIndex = ctx.firstParagraphNum - 1;
-              console.log('[MATCH] Valid progression:', isSameParagraph ? 'same paragraph' : isNextParagraph ? 'next paragraph' : 're-lock');
+              console.log('[MATCH] Valid progression:', isSameParagraph ? 'same paragraph' : isNextParagraph ? 'next paragraph' : isPrevParagraph ? 'previous paragraph' : 're-lock');
             } else {
               // Non-sequential jump or new section: reset highlight to current paragraph
               firstParagraphIndex = currentParagraphIndex;
@@ -458,7 +460,8 @@ export default function App() {
               currentStart: currentParagraphStart,  // For scrolling to current paragraph
               currentEnd: currentParagraphEnd,
               contextStart: 0,
-              contextEnd: content.text.length
+              contextEnd: content.text.length,
+              firstParagraphNum: firstParagraphIndex + 1  // Signals non-contiguous jump when it changes
             };
 
             console.log('[MATCH] Paragraph-based highlight: paragraphs', firstParagraphIndex + 1, 'to', currentParagraphIndex + 1,
@@ -908,13 +911,9 @@ export default function App() {
       webMediaStreamRef.current = null;
     }
 
-    // Clean up AudioContext if it exists
+    // Clean up AudioContext if it exists — fire and forget so it doesn't block setIsRecording(false)
     if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
-      try {
-        await audioContextRef.current.close();
-      } catch (err) {
-        debugLog('Error closing AudioContext:', err);
-      }
+      audioContextRef.current.close().catch(err => debugLog('Error closing AudioContext:', err));
       audioContextRef.current = null;
     }
 

--- a/README.md
+++ b/README.md
@@ -97,3 +97,10 @@ This project uses Expo's managed workflow, which provides:
 - [Expo Documentation](https://docs.expo.dev/)
 - [React Native Documentation](https://reactnative.dev/)
 - [Expo Audio Documentation](https://docs.expo.dev/versions/latest/sdk/av/)
+
+## Ideas
+
+- Allow users to search writings
+- text to voice ?
+- highlight just the parts read
+- allow reading to start in the middel of a paragrpahs

--- a/tests/matching/run-tests.mjs
+++ b/tests/matching/run-tests.mjs
@@ -28,7 +28,8 @@ const testFiles = specificTest ? [specificTest] : [
   '../fixtures/unique-text-kit-b-i-q-n-noah-story-test.js',
   '../fixtures/common-phrase-o-son-of-arabic-1-test.js',
   '../fixtures/long-text-epistle-mid-paragraph-test.js',
-  '../fixtures/short-prayer-with-noise-test.js'
+  '../fixtures/short-prayer-with-noise-test.js',
+  '../fixtures/iqan-paragraph-79-oscillation-test.js'
 ];
 
 console.log('='.repeat(70));


### PR DESCRIPTION
## Summary

- Adds `isPrevParagraph` as a valid progression case: the 45-word sliding window can temporarily match the previous paragraph when near a section boundary, which previously caused spurious highlight resets
- Adds `firstParagraphNum` to the `highlightPosition` object so `MatchedTextWidget` can detect non-contiguous jumps and reset auto-scroll accordingly
- Adds `iqan-paragraph-79-oscillation-test` fixture to the matching test run list
- Adds ideas section to README

## Test plan

- [x] `npm run test:matching` — 23/23 fixture stages passing (including the iqan oscillation fixture)